### PR TITLE
Fix to handle deletions at end of read

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -192,6 +192,9 @@ pub fn run(input: &str, output: &str, genome: &str) {
                     let mut tmp_count = 1;
     
                     while flag_tmp != 2 {
+                        if idx + tmp_count > target_read_seq.len() - 1 {
+                            break
+                        }
                         if char_at(&target_read_seq, idx + tmp_count) != '-' {
                             tmp_target_read_seq.push(char_at(&target_read_seq, idx + tmp_count));
                             tmp_target_ref_seq.push(char_at(&target_ref_seq, idx + tmp_count));


### PR DESCRIPTION
I found an edge case when running `metheor tag` when looking for trinucelotide bases with reads ending in a deletion. Adding a simple check to confirm length fixes the issue, but would be open to alternatives if you have any ideas!

Here is an example of a read that breaks `metheor tag`:
```
test        161     chr1    35576935        60      1M13D4M4D139M   =       35576985        193     CATACACAACCACAAAACCCCAACACCAACAAAACCCCAACACCAACAAAACCCCAACACCAACAAAACCCCAACACCAACAAAACCCCAACACCAACAAAACNATAACCCAATAAAACAAATAAAACACTCACAACCTAAACA ?????????????????????????????????????????????????????????????????????????????????????????????????????7?!7????????7?????????????????7??????7?????      RG:Z:test
```

Which returned the following error before the fix:
```
Parsing reference genome...
Done!
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/tag.rs:26:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```